### PR TITLE
Fix Errors Found By Pylint

### DIFF
--- a/pyclient/setup.py
+++ b/pyclient/setup.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
-from __future__ import print_function
-
 import os
 import subprocess
 

--- a/pyclient/wallet/simplewallet_cli.py
+++ b/pyclient/wallet/simplewallet_cli.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
-from __future__ import print_function
 import argparse
 import getpass
 import logging
@@ -237,9 +236,6 @@ def main(prog_name=os.path.basename(sys.argv[0]), args=None):
 def main_wrapper():
     try:
         main()
-    except Exception as err:
-        print("Error: {}".format(err), file=sys.stderr)
-        sys.exit(1)
     except KeyboardInterrupt:
         pass
     except SystemExit as err:

--- a/pyclient/wallet/simplewallet_client.py
+++ b/pyclient/wallet/simplewallet_client.py
@@ -15,7 +15,6 @@
 
 import hashlib
 import base64
-from base64 import b64encode
 import time
 import requests
 import yaml
@@ -32,13 +31,13 @@ from sawtooth_sdk.protobuf.batch_pb2 import BatchHeader
 from sawtooth_sdk.protobuf.batch_pb2 import Batch
 
 # The Transaction Family Name
-FAMILY_NAME='simplewallet'
+FAMILY_NAME = 'simplewallet'
 
 def _hash(data):
     return hashlib.sha512(data).hexdigest()
 
 
-class SimpleWalletClient:
+class SimpleWalletClient(object):
     def __init__(self, baseUrl, keyFile=None):
 
         self._baseUrl = baseUrl
@@ -52,17 +51,17 @@ class SimpleWalletClient:
                 privateKeyStr = fd.read().strip()
         except OSError as err:
             raise Exception('Failed to read private key {}: {}'.format(
-                    keyFile, str(err)))
+                keyFile, str(err)))
 
         try:
             privateKey = Secp256k1PrivateKey.from_hex(privateKeyStr)
-        except ParseError as e:
-            raise Exception('Failed to load private key: {}'.format(str(e)))
+        except ParseError as err:
+            raise Exception('Failed to load private key: {}'.format(str(err)))
 
         self._signer = CryptoFactory(create_context('secp256k1')) \
             .new_signer(privateKey)
 
-        self._publicKey = self._signer.get_public_key().as_hex();
+        self._publicKey = self._signer.get_public_key().as_hex()
 
         self._address = _hash(FAMILY_NAME.encode('utf-8'))[0:6] + \
             _hash(self._publicKey.encode('utf-8'))[0:64]
@@ -80,10 +79,9 @@ class SimpleWalletClient:
     def withdraw(self, value):
         try:
             retValue = self._wrap_and_send(
-            "withdraw",
-            value)
-            #raise Exception('Encountered an error during withdrawal {}'.format(retValue) )
-        except Exception as e:
+                "withdraw",
+                value)
+        except Exception:
             raise Exception('Encountered an error during withdrawal')
         return retValue
 
@@ -92,14 +90,14 @@ class SimpleWalletClient:
             with open(clientToKey) as fd:
                 publicKeyStr = fd.read().strip()
             retValue = self._wrap_and_send(
-            "transfer",
-            value,
-            publicKeyStr)
+                "transfer",
+                value,
+                publicKeyStr)
         except OSError as err:
             raise Exception('Failed to read public key {}: {}'.format(
-                    clientToKey, str(err)))
-        except Exception as e:
-            raise Exception('Encountered an error during transfer',e)
+                clientToKey, str(err)))
+        except Exception as err:
+            raise Exception('Encountered an error during transfer', err)
         return retValue
 
     def balance(self):
@@ -112,9 +110,9 @@ class SimpleWalletClient:
             return None
 
     def _send_to_restapi(self,
-                      suffix,
-                      data=None,
-                      contentType=None):
+                         suffix,
+                         data=None,
+                         contentType=None):
         if self._baseUrl.startswith("http://"):
             url = "{}/{}".format(self._baseUrl, suffix)
         else:
@@ -145,8 +143,8 @@ class SimpleWalletClient:
         return result.text
 
     def _wrap_and_send(self,
-                     action,
-                     *values):
+                       action,
+                       *values):
 
         # Generate a csv utf-8 encoded string as payload
         rawPayload = action
@@ -189,7 +187,7 @@ class SimpleWalletClient:
 
         transactionList = [transaction]
 
-        # Create a BatchHeader from TransactionList above
+        # Create a BatchHeader from transactionList above
         header = BatchHeader(
             signer_public_key=self._publicKey,
             transaction_ids=[txn.header_signature for txn in transactionList]

--- a/pyclient/wallet/simplewallet_message_factory.py
+++ b/pyclient/wallet/simplewallet_message_factory.py
@@ -15,7 +15,7 @@
 
 from sawtooth_processor_test.message_factory import MessageFactory
 
-class SimplewalletMessageFactory:
+class SimplewalletMessageFactory(object):
     def __init__(self, signer=None):
         self._factory = MessageFactory(
             family_name="simplewallet",
@@ -63,7 +63,7 @@ class SimplewalletMessageFactory:
         if value is not None:
             data = str(value).encode()
         else:
-            data = None 
+            data = None
         return self._factory.create_set_request({address: data})
 
     def create_get_response(self, value):
@@ -72,7 +72,7 @@ class SimplewalletMessageFactory:
         if value is not None:
             data = str(value).encode()
         else:
-            data = None 
+            data = None
         return self._factory.create_get_response({address: data})
 
     def create_set_response(self, game):

--- a/pyprocessor/processor/simplewallet_tp.py
+++ b/pyprocessor/processor/simplewallet_tp.py
@@ -49,7 +49,7 @@ class SimpleWalletTransactionHandler(TransactionHandler):
         payload_list = transaction.payload.decode().split(",")
         operation = payload_list[0]
         amount = payload_list[1]
-        
+
         from_key = header.signer_public_key
 
         LOGGER.info("Operation = "+ operation)
@@ -95,7 +95,7 @@ class SimpleWalletTransactionHandler(TransactionHandler):
         else:
             balance = int(current_entry[0].data)
             if balance < int(amount):
-                raise InvalidTransaction('Not enough money. Tha amount should be lesser or equal to {} '.format(value))
+                raise InvalidTransaction('Not enough money. The amount should be lesser or equal to {} '.format(balance))
             else:
                 new_balance = balance - int(amount)
 


### PR DESCRIPTION
1. Replace non-existent variable "value" with "balance"

2. Remove unused variables

3. Remove "from __future__ import print_function" (not needed for Python 3)

4. Derive classes from parent class "object" when no other derivation is present

5. Fix other minor format issues (indenting, missing spaces, trailing spaces)

Signed-off-by: danintel <daniel.anderson@intel.com>