### PR TITLE
Corrections for Javascript Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,25 +21,29 @@ The application is built in two parts:
 
 ------
 
-**NOTE**
+**JAVASCRIPT CLIENT NOTE**
 
 The client is also written in Javascript using node.js. The `app.js` is the main javascript file from where the `main` function call occurs. Handlebars are used for templating, client related CSS and JavaScript code is written in public folder and server related files are written in `router/` folder. Running the default `docker-compose.yaml` file or the `simplewallet-build-client-js.yaml` launches the client, which is accessible at `localhost:3000`. 
 
 How to use the simplewallet UI:
 
-1. Open bash shell in `simplewallet-client-js` container:
+1. Build and start the Docker containers:
+
+`docker-compose -f simplewallet-build-client-js.yaml up`
+
+2. Open bash shell in `simplewallet-client-js` container:
 
 `docker exec -it simplewallet-client-js bash`
 
-2. Create user accounts for jack and jill:
+3. Create user accounts for jack and jill:
 
 `sawtooth keygen jack && sawtooth keygen jill`
 
-3. Open two new browser tabs and go to `localhost:3000` on each tab
+4. Open two new browser tabs and go to `http://localhost:3000` on each tab
 
-4. Login in one tab as `jack` and in other as `jill` 
+5. Login in one tab as `jack` and in other as `jill` 
 
-5. Start with an initial deposit for each user - jack and jill via the `Deposit` tab in the UI homepage
+6. Start with an initial deposit for each user - jack and jill via the `Deposit` tab in the UI homepage
 
 ------
 

--- a/simplewallet-build-client-js.yaml
+++ b/simplewallet-build-client-js.yaml
@@ -36,7 +36,7 @@ services:
     environment:
       - 'http_proxy=${http_proxy}'
       - 'https_proxy=${https_proxy}'
-      - 'no_proxy=rest-api,validator,{no_proxy}'
+      - 'no_proxy=rest-api,validator,${no_proxy}'
     volumes:
       - '.:/project/simplewallet/'
     ports:
@@ -75,9 +75,9 @@ services:
     command: |
       bash -c "
         if [ ! -f /etc/sawtooth/keys/validator.priv ]; then
-          sawadm keygen && 
-          sawtooth keygen my_key && 
-          sawset genesis -k /root/.sawtooth/keys/my_key.priv && 
+          sawadm keygen &&
+          sawtooth keygen my_key &&
+          sawset genesis -k /root/.sawtooth/keys/my_key.priv &&
           sawadm genesis config-genesis.batch
         fi;
         sawtooth-validator -vvv \


### PR DESCRIPTION
Corrections for Javascript Client

1. Fix syntax error in simplewallet-build-client-js.yaml :
   s/{no_proxy}/${no_proxy}/

2. Add missing docker-compose instruction in README.md for Javascript client.

Signed-off-by: danintel <daniel.anderson@intel.com>