### PR TITLE
javaprocessor related updates

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -66,7 +66,7 @@ services:
     expose:
       - 4004
     ports:
-      - '4040:4004'
+      - '4004:4004'
     command: |
       bash -c "
         if [ ! -f /etc/sawtooth/keys/validator.priv ]; then

--- a/javaprocessor/build_java_processor.sh
+++ b/javaprocessor/build_java_processor.sh
@@ -28,7 +28,7 @@ mvn clean install -Dhttp.proxyHost=$http_proxy_host \
     -Dhttp.proxyPort=$http_proxy_port \
     -Dhttps.proxyHost=$https_proxy_host \
     -Dhttps.proxyPort=$https_proxy_port
-
+rm -rf /project/sawtooth-core
 echo "Build Simplewallet java transaction processor.."
 cd $current_dir
 mvn clean install \

--- a/javaprocessor/build_java_processor.sh
+++ b/javaprocessor/build_java_processor.sh
@@ -20,10 +20,8 @@ fi
 mkdir -p /project/
 current_dir=`pwd`
 cd /project
-git clone https://github.com/hyperledger/sawtooth-core.git
+git clone -b 1-0 --single-branch https://github.com/hyperledger/sawtooth-core.git
 cd /project/sawtooth-core/
-git fetch --all
-git checkout 1-0
 echo "Building sawtooth java sdk dependency.."
 cd sdk/java
 mvn clean install -Dhttp.proxyHost=$http_proxy_host \


### PR DESCRIPTION
- Fixed the javaprocessor build script
-- Changed git clone ops to clone only a single branch i.e. 1-0 for sawtooth-core
-- Removed sawtooth-core cloned directory after mvn install i.e. sawtooth-java-sdk is installed in the javaprocessor docker container

- Fixed the default ports for validator container in default docker-compose.yaml file