### PR TITLE
Use Random Number instead of Timestamp for Nonce

### DIFF
--- a/cxxprocessor/Dockerfile
+++ b/cxxprocessor/Dockerfile
@@ -42,4 +42,4 @@ EXPOSE 4004/tcp
 
 WORKDIR /project/simplewallet/cxxprocessor
 
-CMD bash -c "./build.sh && ./bin/simplewallet-tp"
+CMD bash -c "./build.sh"

--- a/cxxprocessor/build.sh
+++ b/cxxprocessor/build.sh
@@ -22,3 +22,4 @@ mkdir -p build
 cd build
 cmake ..
 make
+./bin/simplewallet-tp tcp://validator:4004

--- a/jsclient/public/js/main.js
+++ b/jsclient/public/js/main.js
@@ -116,7 +116,7 @@ function showBalance() {
     var userId = sessionStorage.getItem('userId');
     $.post('/balance', { userId: userId },
          function (data, textStatus, jqXHR) {
-              document.getElementById("balanceCheck").innerHTML ="Your balance is:" + "<br />"  + "Rs " + data.balance; 
+              document.getElementById("balanceCheck").innerHTML ="Your balance is:" + "<br />" + data.balance; 
             },
             'json'); 
 }

--- a/jsclient/routes/SimpleWalletClient.js
+++ b/jsclient/routes/SimpleWalletClient.js
@@ -97,7 +97,7 @@ class SimpleWalletClient {
       inputs: inputAddressList,
       outputs: outputAddressList,
       signerPublicKey: this.signer.getPublicKey().asHex(),
-      nonce: "" + new Date().getTime(),
+      nonce: "" + Math.random(),
       batcherPublicKey: this.signer.getPublicKey().asHex(),
       dependencies: [],
       payloadSha512: hash(payloadBytes),

--- a/jsclient/views/loginPage.handlebars
+++ b/jsclient/views/loginPage.handlebars
@@ -19,9 +19,9 @@
             <!-- form end-->
 	     <br />
 	     <br />
-	     <pre style="background-color: rgb(59,56,56); color:white; text-align:center; font-family:'Open Sans', sans-serif; font-weight:normal; font-size: 14px;"> Please refer     
+	     <pre style="background-color: rgb(59,56,56); color:white; text-align:center; font-family:'Open Sans', sans-serif; font-weight:normal; font-size: 14px;"> Please refer to     
 https://github.com/askmish/sawtooth-simplewallet/blob/master/README.md 
-    to know how to create the username.
+    to learn how to create the username.
             </pre>
         </div>
         <div class="col-md-4 col-sm-4 col-xs-12"> </div>

--- a/pyclient/wallet/simplewallet_client.py
+++ b/pyclient/wallet/simplewallet_client.py
@@ -18,7 +18,7 @@ This SimpleWalletClient class interfaces with Sawtooth through the REST API.
 
 import hashlib
 import base64
-import time
+import random
 import requests
 import yaml
 
@@ -193,7 +193,7 @@ class SimpleWalletClient(object):
             dependencies=[],
             payload_sha512=_hash(payload),
             batcher_public_key=self._publicKey,
-            nonce=time.time().hex().encode()
+            nonce=random.random().hex().encode()
         ).SerializeToString()
 
         # Create a Transaction from the header and payload above


### PR DESCRIPTION
1. Use random number for nonce.
Timestamps have a greater chance of collision as parallel
transaction processing increases (either through threads
or multiple processes).

2. Fix cxxprocessor build and run.

3. In JS client, remove country-specific currency symbol (Rs)
and reword username help message.

Signed-off-by: danintel <daniel.anderson@intel.com>