### PR TITLE
Fix NameError: name 'traceback' is not defined

### DIFF
--- a/pyprocessor/processor/simplewallet_tp.py
+++ b/pyprocessor/processor/simplewallet_tp.py
@@ -14,6 +14,8 @@
 Transaction family class for simplewallet.
 '''
 
+import traceback
+import sys
 import hashlib
 import logging
 


### PR DESCRIPTION
Add "import traceback" and "import sys" at the top of simplewallet_tp.py.

Signed-off-by: danintel <daniel.anderson@intel.com>